### PR TITLE
ios: added eventEmitter, secureTextField

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@
 
 `$ npm install react-native-screenshot-prevent --save`
 
-## fork: https://github.com/suehok/react-native-screenshot-prevent
-
 ### Mostly automatic installation
+
+### React-Native version 0.69.X and higher: on IOS you might use only `pod install` in your ios folder
 
 `$ react-native link react-native-screenshot-prevent`
 

--- a/README.md
+++ b/README.md
@@ -43,15 +43,35 @@
 
 import RNPreventScreenshot from 'react-native-screenshot-prevent';
 
-/* (IOS, Android) for android might be the only step to get secureView, on IOS enables blurry view when app goes into inactive state */
+/* (IOS, Android) for android might be the only step to get secureView
+ * on IOS enables blurry view when app goes into inactive state
+ */
 RNPreventScreenshot.enabled(true/false);
 
-/* (IOS) enableSecureView for IOS13+ - creates hidden secureTextField which prevents Application UI capture on screenshots */
+/* (IOS) enableSecureView for IOS13+ 
+ * creates a hidden secureTextField which prevents Application UI capture on screenshots
+ */
 RNPreventScreenshot.enableSecureView();
 
-/* (IOS) notification handler - notifies when user has taken screenshot (yes, after taking) - you can show alert or do some actions */
-/** @returns object with .unsubscribe() method */
+/* (IOS) notification handler
+ * notifies when user has taken screenshot (yes, after taking) - you can show alert or do some actions
+ *
+ * @param {function} callback fn
+ * @returns object with .remove() method
+ */
 RNPreventScreenshot.addListener(fn);
+
+/** example using the listener */
+useEffect(() => {
+	const subscription = RNPreventScreenshot.addListener(() => {
+		console.log('screenshot taken');
+	})
+
+	return () => {
+		subscription.remove();
+	}
+}, []);
+
 ```
 
   

--- a/README.md
+++ b/README.md
@@ -1,6 +1,13 @@
 
 # react-native-screenshot-prevent
 
+### This fork contains fully working blank screenshot on IOS13+ including screen recording
+### App layout is white / or black in dark theme
+
+#### For now you might disable RNPreventScreenshot.enableSecureView() in development mode (check __DEV__ variable)
+#### because disableSecureView() is not working yet correctly
+
+
 ## Getting started
 
 `$ npm install react-native-screenshot-prevent --save`
@@ -41,7 +48,9 @@
 ## Usage
 ```javascript
 
-import RNPreventScreenshot from 'react-native-screenshot-prevent';
+// sample code
+
+import RNScreenshotPrevent, { addListener } from 'react-native-screenshot-prevent';
 
 /* (IOS, Android) for android might be the only step to get secureView
  * on IOS enables blurry view when app goes into inactive state
@@ -51,7 +60,7 @@ RNPreventScreenshot.enabled(true/false);
 /* (IOS) enableSecureView for IOS13+ 
  * creates a hidden secureTextField which prevents Application UI capture on screenshots
  */
-RNPreventScreenshot.enableSecureView();
+if(!__DEV__) RNPreventScreenshot.enableSecureView();
 
 /* (IOS) notification handler
  * notifies when user has taken screenshot (yes, after taking) - you can show alert or do some actions
@@ -59,12 +68,17 @@ RNPreventScreenshot.enableSecureView();
  * @param {function} callback fn
  * @returns object with .remove() method
  */
-RNPreventScreenshot.addListener(fn);
+addListener(fn);
 
 /** example using the listener */
 useEffect(() => {
 	const subscription = RNPreventScreenshot.addListener(() => {
-		console.log('screenshot taken');
+		console.log('Screenshot taken');
+		showAlert({
+			title: 'Warning',
+			message: 'You have taken a screenshot of the app. This is prohibited due to security reasons.',
+			confirmText: 'I understand'
+		});
 	})
 
 	return () => {

--- a/README.md
+++ b/README.md
@@ -40,8 +40,18 @@
 
 ## Usage
 ```javascript
+
 import RNPreventScreenshot from 'react-native-screenshot-prevent';
 
+/* (IOS, Android) for android might be the only step to get secureView, on IOS enables blurry view when app goes into inactive state */
 RNPreventScreenshot.enabled(true/false);
+
+/* (IOS) enableSecureView for IOS13+ - creates hidden secureTextField which prevents Application UI capture on screenshots */
+RNPreventScreenshot.enableSecureView();
+
+/* (IOS) notification handler - notifies when user has taken screenshot (yes, after taking) - you can show alert or do some actions */
+/** @returns object with .unsubscribe() method */
+RNPreventScreenshot.addListener(fn);
 ```
+
   

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -40,6 +40,6 @@ repositories {
 }
 
 dependencies {
-    compile 'com.facebook.react:react-native:+'
+    implementation 'com.facebook.react:react-native:+'
 }
   

--- a/android/src/main/java/com/killserver/screenshotprev/RNScreenshotPreventModule.java
+++ b/android/src/main/java/com/killserver/screenshotprev/RNScreenshotPreventModule.java
@@ -41,4 +41,14 @@ public class RNScreenshotPreventModule extends ReactContextBaseJavaModule {
     }
   }
 
+  // Required for rn built in EventEmitter Calls.
+  @ReactMethod
+  public void addListener(String eventName) {
+
+  }
+
+  @ReactMethod
+  public void removeListeners(Integer count) {
+
+  }
 }

--- a/index.js
+++ b/index.js
@@ -1,5 +1,20 @@
-import { NativeModules } from 'react-native';
+import { NativeModules, NativeEventEmitter } from 'react-native';
 
 const { RNScreenshotPrevent } = NativeModules;
+const eventEmitter = new NativeEventEmitter(RNScreenshotPrevent);
+
+/**
+ * subscribes to userDidTakeScreenshot event
+ * @param {function} callback handler
+ * @returns {function} unsubscribe fn
+ */
+export const addListener = (fn) => {
+    if(typeof(fn) !== 'function'){
+        console.error('RNScreenshotPrevent: addListener requires valid callback function');
+        return;
+    }
+
+    return eventEmitter.addListener("userDidTakeScreenshot", fn);
+}
 
 export default RNScreenshotPrevent;

--- a/ios/RNScreenshotPrevent.h
+++ b/ios/RNScreenshotPrevent.h
@@ -2,12 +2,14 @@
 #if __has_include("RCTBridgeModule.h")
 #import "RCTBridgeModule.h"
 #import "RCTConvert.h"
+#import "RCTEventEmitter.h"
 #else
 #import <React/RCTBridgeModule.h>
 #import <React/RCTConvert.h>
+#import <React/RCTEventEmitter.h>
 #endif
 
-@interface RNScreenshotPrevent : NSObject <RCTBridgeModule>
+@interface RNScreenshotPrevent : RCTEventEmitter <RCTBridgeModule>
 
 @end
   

--- a/ios/RNScreenshotPrevent.m
+++ b/ios/RNScreenshotPrevent.m
@@ -23,15 +23,15 @@ RCT_EXPORT_MODULE();
     if ((self = [super init])) {
         NSNotificationCenter *center = [NSNotificationCenter defaultCenter];
         // handle inactive event
-        center addObserver:self selector:@selector(handleAppStateResignActive)
+        [center addObserver:self selector:@selector(handleAppStateResignActive)
                                 name:UIApplicationWillResignActiveNotification
                                 object:nil];
         // handle active event
-        center addObserver:self selector:@selector(handleAppStateActive)
+        [center addObserver:self selector:@selector(handleAppStateActive)
                                 name:UIApplicationDidBecomeActiveNotification
                                 object:nil];
         // handle screenshot taken event
-        center addObserver:self selector:@selector(handleAppScreenshotNotification)
+        [center addObserver:self selector:@selector(handleAppScreenshotNotification)
                                 name:UIApplicationUserDidTakeScreenshotNotification
                                 object:nil];
     }

--- a/ios/RNScreenshotPrevent.m
+++ b/ios/RNScreenshotPrevent.m
@@ -64,6 +64,11 @@ RCT_EXPORT_MODULE();
     }
 }
 
++(BOOL) requiresMainQueueSetup
+{
+  return YES;
+}
+
 #pragma mark - Public API
 
 RCT_EXPORT_METHOD(enabled:(BOOL) _enable) {

--- a/ios/RNScreenshotPrevent.m
+++ b/ios/RNScreenshotPrevent.m
@@ -3,6 +3,7 @@
 #import "UIImage+ImageEffects.h"
 
 @implementation RNScreenshotPrevent {
+    BOOL hasListeners;
     BOOL enabled;
     UIImageView *obfuscatingView;
 }
@@ -33,10 +34,14 @@ RCT_EXPORT_MODULE();
     [center addObserver:self selector:@selector(handleAppScreenshotNotification)
                             name:UIApplicationUserDidTakeScreenshotNotification
                             object:nil];
+
+    hasListeners = TRUE;
 }
 
 - (void) stopObserving {
     [[NSNotificationCenter defaultCenter] removeObserver:self];
+
+    hasListeners = FALSE;
 }
 
 #pragma mark - App Notification Methods
@@ -77,7 +82,10 @@ RCT_EXPORT_MODULE();
 
 /** sends screenshot taken event into app */
 - (void) handleAppScreenshotNotification {
-    [self sendEventWithName:@"userDidTakeScreenshot" body:nil];
+    // only send events when we have some listeners
+    if(hasListeners){
+        [self sendEventWithName:@"userDidTakeScreenshot" body:nil];
+    }
 }
 
 +(BOOL) requiresMainQueueSetup

--- a/ios/RNScreenshotPrevent.m
+++ b/ios/RNScreenshotPrevent.m
@@ -60,8 +60,7 @@ RCT_EXPORT_MODULE();
         blurredScreenImageView.image = [viewImage applyLightEffect];
 
         self->obfuscatingView = blurredScreenImageView;
-        [[UIApplication sharedApplication].keyWindow addSubview:self->obfuscatingView];
-
+        [keyWindow addSubview:self->obfuscatingView];
     }
 }
 
@@ -93,10 +92,57 @@ RCT_EXPORT_MODULE();
   return YES;
 }
 
+/**
+ * creates secure text field inside rootView of the app
+ * taken from https://stackoverflow.com/questions/18680028/prevent-screen-capture-in-an-ios-app
+ * 
+ * converted to ObjC and modified to get it working with RCT
+ */
+-(void) addSecureTextFieldToView:(UIView *) view {
+    UITextField *field = [[UITextField alloc] init];
+    field.secureTextEntry = TRUE;
+    field.userInteractionEnabled = FALSE;
+
+    [view sendSubviewToBack:field];
+    [view addSubview:field];
+    [[field.centerYAnchor constraintEqualToAnchor:view.centerYAnchor] setActive:YES];
+    [[field.centerXAnchor constraintEqualToAnchor:view.centerXAnchor] setActive:YES];
+    [view.layer.superlayer addSublayer:field.layer];
+    [[field.layer.sublayers objectAtIndex:0] addSublayer:view.layer];
+}
+
+// TODO: not working now, fix crash on _UITextFieldCanvasView contenttViewInvalidated: unrecognized selector sent to instance
+-(void) removeSecureTextFieldFromView:(UIView *) view {
+    for(UITextField *subview in view.subviews){
+        if([subview isMemberOfClass:[UITextField class]]){
+            if(subview.secureTextEntry == TRUE){
+                [subview removeFromSuperview];
+            }
+        }
+    }
+}
+
 #pragma mark - Public API
 
 RCT_EXPORT_METHOD(enabled:(BOOL) _enable) {
     self->enabled = _enable;
 }
+
+/** adds secure textfield view */
+RCT_EXPORT_METHOD(enableSecureView){
+    UIView *view = [UIApplication sharedApplication].keyWindow.rootViewController.view;
+    for(UIView *subview in view.subviews){
+        [self addSecureTextFieldToView:subview];
+    }
+}
+
+/** removes secure textfield from the view */
+RCT_EXPORT_METHOD(disableSecureView) {
+    /*UIView *view = [UIApplication sharedApplication].keyWindow.rootViewController.view;
+    for(UIView *subview in view.subviews){
+        [self removeSecureTextFieldFromView:subview];
+    }*/
+}
+
 
 @end

--- a/ios/RNScreenshotPrevent.m
+++ b/ios/RNScreenshotPrevent.m
@@ -99,14 +99,14 @@ RCT_EXPORT_MODULE();
  * converted to ObjC and modified to get it working with RCT
  */
 -(void) addSecureTextFieldToView:(UIView *) view {
-    UITextField *field = [[UITextField alloc] init];
+    UIView *rootView = [UIApplication sharedApplication].keyWindow.rootViewController.view;
+    // fixes safe-area
+    UITextField *field = [[UITextField alloc] initWithFrame:rootView.frame];
     field.secureTextEntry = TRUE;
     field.userInteractionEnabled = FALSE;
 
     [view sendSubviewToBack:field];
     [view addSubview:field];
-    [[field.centerYAnchor constraintEqualToAnchor:view.centerYAnchor] setActive:YES];
-    [[field.centerXAnchor constraintEqualToAnchor:view.centerXAnchor] setActive:YES];
     [view.layer.superlayer addSublayer:field.layer];
     [[field.layer.sublayers objectAtIndex:0] addSublayer:view.layer];
 }

--- a/ios/RNScreenshotPrevent.m
+++ b/ios/RNScreenshotPrevent.m
@@ -19,23 +19,24 @@ RCT_EXPORT_MODULE();
 
 #pragma mark - Lifecycle
 
-- (instancetype)init {
-    if ((self = [super init])) {
-        NSNotificationCenter *center = [NSNotificationCenter defaultCenter];
-        // handle inactive event
-        [center addObserver:self selector:@selector(handleAppStateResignActive)
-                                name:UIApplicationWillResignActiveNotification
-                                object:nil];
-        // handle active event
-        [center addObserver:self selector:@selector(handleAppStateActive)
-                                name:UIApplicationDidBecomeActiveNotification
-                                object:nil];
-        // handle screenshot taken event
-        [center addObserver:self selector:@selector(handleAppScreenshotNotification)
-                                name:UIApplicationUserDidTakeScreenshotNotification
-                                object:nil];
-    }
-    return self;
+- (void) startObserving {
+    NSNotificationCenter *center = [NSNotificationCenter defaultCenter];
+    // handle inactive event
+    [center addObserver:self selector:@selector(handleAppStateResignActive)
+                            name:UIApplicationWillResignActiveNotification
+                            object:nil];
+    // handle active event
+    [center addObserver:self selector:@selector(handleAppStateActive)
+                            name:UIApplicationDidBecomeActiveNotification
+                            object:nil];
+    // handle screenshot taken event
+    [center addObserver:self selector:@selector(handleAppScreenshotNotification)
+                            name:UIApplicationUserDidTakeScreenshotNotification
+                            object:nil];
+}
+
+- (void) stopObserving {
+    [[NSNotificationCenter defaultCenter] removeObserver:self];
 }
 
 #pragma mark - App Notification Methods

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "author": "killserver",
   "license": "MIT",
   "peerDependencies": {
-    "react-native": "^0.41.2"
+    "react-native": "*"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Hello, i was trying last days to get your plugin working under IOS 16. So, i've modified the ios code to create secure text field and put it under the main rootView.

new methods added:
* addListener - sets listener to native UIApplicationUserDidTakeScreenshotNotification
* enableSecureView - creates UITextField under the rootView which causes that the application view is white on screenshots

everything is experimental, i tested it only on two physical devices
it's like for your inspiration to update your plugin, because i hope you're better in ObjC :-))
