### PR TITLE
Fix NullPointerException on Android

### DIFF
--- a/android/src/main/java/com/killserver/screenshotprev/RNScreenshotPreventModule.java
+++ b/android/src/main/java/com/killserver/screenshotprev/RNScreenshotPreventModule.java
@@ -24,20 +24,22 @@ public class RNScreenshotPreventModule extends ReactContextBaseJavaModule {
 
   @ReactMethod
   public void enabled(boolean _enable) {
-    if (_enable) {
-      this.reactContext.getCurrentActivity().runOnUiThread(new Runnable() {
-        @Override
-        public void run() {
-          reactContext.getCurrentActivity().getWindow().setFlags(WindowManager.LayoutParams.FLAG_SECURE, WindowManager.LayoutParams.FLAG_SECURE);
-        }
-      });
-    } else {
-      this.reactContext.getCurrentActivity().runOnUiThread(new Runnable() {
-        @Override
-        public void run() {
-          reactContext.getCurrentActivity().getWindow().clearFlags(WindowManager.LayoutParams.FLAG_SECURE);
-        }
-      });
+    if(this.reactContext != null){
+      if (_enable) {
+        this.reactContext.getCurrentActivity().runOnUiThread(new Runnable() {
+          @Override
+          public void run() {
+            reactContext.getCurrentActivity().getWindow().setFlags(WindowManager.LayoutParams.FLAG_SECURE, WindowManager.LayoutParams.FLAG_SECURE);
+          }
+        });
+      } else {
+        this.reactContext.getCurrentActivity().runOnUiThread(new Runnable() {
+          @Override
+          public void run() {
+            reactContext.getCurrentActivity().getWindow().clearFlags(WindowManager.LayoutParams.FLAG_SECURE);
+          }
+        });
+      }
     }
   }
 

--- a/ios/RNScreenshotPrevent.m
+++ b/ios/RNScreenshotPrevent.m
@@ -138,10 +138,10 @@ RCT_EXPORT_METHOD(enableSecureView){
 
 /** removes secure textfield from the view */
 RCT_EXPORT_METHOD(disableSecureView) {
-    UIView *view = [UIApplication sharedApplication].keyWindow.rootViewController.view;
+    /*UIView *view = [UIApplication sharedApplication].keyWindow.rootViewController.view;
     for(UIView *subview in view.subviews){
         [self removeSecureTextFieldFromView:subview];
-    }
+    }*/
 }
 
 

--- a/ios/RNScreenshotPrevent.m
+++ b/ios/RNScreenshotPrevent.m
@@ -138,10 +138,10 @@ RCT_EXPORT_METHOD(enableSecureView){
 
 /** removes secure textfield from the view */
 RCT_EXPORT_METHOD(disableSecureView) {
-    /*UIView *view = [UIApplication sharedApplication].keyWindow.rootViewController.view;
+    UIView *view = [UIApplication sharedApplication].keyWindow.rootViewController.view;
     for(UIView *subview in view.subviews){
         [self removeSecureTextFieldFromView:subview];
-    }*/
+    }
 }
 
 


### PR DESCRIPTION
**Crash Logs on Android**

`java.lang.NullPointerException: Attempt to invoke virtual method 'void android.app.Activity.runOnUiThread(java.lang.Runnable)' on a null object reference at com.killserver.screenshotprev.RNScreenshotPreventModule.enabled(RNScreenshotPreventModule.java:35) at java.lang.reflect.Method.invoke(Method.java:-2) at com.facebook.react.bridge.JavaMethodWrapper.invoke(JavaMethodWrapper.java:372) at com.facebook.react.bridge.JavaModuleWrapper.invoke(JavaModuleWrapper.java:188) at com.facebook.react.bridge.queue.NativeRunnable.run(NativeRunnable.java:-2) at android.os.Handler.handleCallback(Handler.java:883) at android.os.Handler.dispatchMessage(Handler.java:100) at com.facebook.react.bridge.queue.MessageQueueThreadHandler.dispatchMessage(MessageQueueThreadHandler.java:27) at android.os.Looper.loop(Looper.java:264) at com.facebook.react.bridge.queue.MessageQueueThreadImpl$4.run(MessageQueueThreadImpl.java:226) at java.lang.Thread.run(Thread.java:919)`