### PR TITLE
Add support for images

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 # react-native-screenshot-prevent
 
 ### This fork contains fully working blank screenshot on IOS13+ including screen recording
+### This fork contains fully working image screenshot cover on IOS13+ including screen recording
 ### App layout is white / or black in dark theme
 
 #### For now you might disable RNPreventScreenshot.enableSecureView() in development mode (check __DEV__ variable)
@@ -62,6 +63,12 @@ RNPreventScreenshot.enabled(true/false);
  * creates a hidden secureTextField which prevents Application UI capture on screenshots
  */
 if(!__DEV__) RNPreventScreenshot.enableSecureView();
+
+/* (IOS) enableSecureView for IOS13+ 
+ * creates a hidden secureTextField which prevents Application UI capture on screenshots
+ * and uses imgUri as the source of the background image (can be both https://, file:///)
+ */
+if(!__DEV__) RNPreventScreenshot.enableSecureView(imgUri);
 
 /* (IOS) disableSecureView for IOS13+ 
  * remove a hidden secureTextField which prevents Application UI capture on screenshots

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,6 +1,6 @@
 declare module 'react-native-screenshot-prevent' {
   export function enabled(value: boolean): void
-  export function enableSecureView(): void;
+  export function enableSecureView(imagePath?: string): void;
   export function disableSecureView(): void;
   export function usePreventScreenshot(): void;
   export function useDisableSecureView(): void;

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,11 +5,15 @@ type FN = (resp: any) => void
 type Return = {
     readonly remove: () => void
 }
-
 let addListen: any, RNScreenshotPrevent: any;
 if(Platform.OS !== "web") {
     const { RNScreenshotPrevent: RNScreenshotPreventNative } = NativeModules;
-    RNScreenshotPrevent = RNScreenshotPreventNative
+    RNScreenshotPrevent = {
+        ...RNScreenshotPreventNative,
+        enableSecureView: function enableSecureView(imagePath = "") {
+            RNScreenshotPreventNative.enableSecureView(imagePath)
+        }
+    }
     const eventEmitter = new NativeEventEmitter(RNScreenshotPrevent);
 
     /**
@@ -78,7 +82,7 @@ export const useDisableSecureView = () => {
 }
 
 export const enabled: (enabled: boolean) => void = RNScreenshotPrevent.enabled
-export const enableSecureView: () => void = RNScreenshotPrevent.enableSecureView
+export const enableSecureView: (imagePath?: string) => void = RNScreenshotPrevent.enableSecureView
 export const disableSecureView: () => void = RNScreenshotPrevent.disableSecureView
 export const addListener: (fn: FN) => void = addListen
 export default RNScreenshotPrevent;


### PR DESCRIPTION
# Description
Add support for images on RNPreventScreenshot.enableSecureView method as argument.
Supports all types of URI such as https:// or file://

Solves https://github.com/killserver/react-native-screenshot-prevent/issues/34 