### PR TITLE
Fix: nullPointerException when `getCurrentActivity()` returns null

### DIFF
--- a/android/src/main/java/com/killserver/screenshotprev/RNScreenshotPreventModule.java
+++ b/android/src/main/java/com/killserver/screenshotprev/RNScreenshotPreventModule.java
@@ -32,14 +32,14 @@ public class RNScreenshotPreventModule extends ReactContextBaseJavaModule {
           activity.runOnUiThread(new Runnable() {
             @Override
             public void run() {
-              reactContext.getCurrentActivity().getWindow().setFlags(WindowManager.LayoutParams.FLAG_SECURE, WindowManager.LayoutParams.FLAG_SECURE);
+              activity.getWindow().setFlags(WindowManager.LayoutParams.FLAG_SECURE, WindowManager.LayoutParams.FLAG_SECURE);
             }
           });
         } else {
           activity.runOnUiThread(new Runnable() {
             @Override
             public void run() {
-              reactContext.getCurrentActivity().getWindow().clearFlags(WindowManager.LayoutParams.FLAG_SECURE);
+              activity.getWindow().clearFlags(WindowManager.LayoutParams.FLAG_SECURE);
             }
           });
         }
@@ -55,7 +55,7 @@ public class RNScreenshotPreventModule extends ReactContextBaseJavaModule {
         activity.runOnUiThread(new Runnable() {
           @Override
           public void run() {
-            reactContext.getCurrentActivity().getWindow().setFlags(WindowManager.LayoutParams.FLAG_SECURE, WindowManager.LayoutParams.FLAG_SECURE);
+            activity.getWindow().setFlags(WindowManager.LayoutParams.FLAG_SECURE, WindowManager.LayoutParams.FLAG_SECURE);
           }
         });
       }
@@ -70,7 +70,7 @@ public class RNScreenshotPreventModule extends ReactContextBaseJavaModule {
         activity.runOnUiThread(new Runnable() {
           @Override
           public void run() {
-            reactContext.getCurrentActivity().getWindow().clearFlags(WindowManager.LayoutParams.FLAG_SECURE);
+            activity.getWindow().clearFlags(WindowManager.LayoutParams.FLAG_SECURE);
           }
         });
       }


### PR DESCRIPTION
In my app there is this error thrown in some scenarios: 

```
NullPointerException: Attempt to invoke virtual method 'android.view.Window android.app.Activity.getWindow()' on a null object reference

at: com.killserver.screenshotprev.RNScreenshotPreventModule$4 in run at line 73
```

This PR should fix it.