### PR TITLE
fixed: Add condition to prevent crash

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
   "engines": {
     "node": ">= 16.0.0"
   },
-  "packageManager": "^yarn@1.22.15",
+  "packageManager": "yarn@1.22.22+sha256.c17d3797fb9a9115bf375e31bfd30058cac6bc9c3b8807a3d8cb2094794b51ca",
   "jest": {
     "preset": "react-native",
     "modulePathIgnorePatterns": [

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,12 +6,16 @@ type Return = {
     readonly remove: () => void
 }
 let addListen: any, RNScreenshotPrevent: any;
-if(Platform.OS !== "web") {
+if (Platform.OS !== "web") {
     const { RNScreenshotPrevent: RNScreenshotPreventNative } = NativeModules;
     RNScreenshotPrevent = {
         ...RNScreenshotPreventNative,
         enableSecureView: function enableSecureView(imagePath = "") {
-            RNScreenshotPreventNative.enableSecureView(imagePath)
+            if (Platform.OS === "ios") {
+                RNScreenshotPreventNative.enableSecureView(imagePath)
+            } else {
+                RNScreenshotPreventNative.enableSecureView()
+            }
         }
     }
     const eventEmitter = new NativeEventEmitter(RNScreenshotPrevent);
@@ -22,7 +26,7 @@ if(Platform.OS !== "web") {
      * @returns {function} unsubscribe fn
      */
     addListen = (fn: FN): Return => {
-        if(typeof(fn) !== 'function') {
+        if (typeof (fn) !== 'function') {
             console.error('RNScreenshotPrevent: addListener requires valid callback function');
             return {
                 remove: (): void => {
@@ -36,7 +40,7 @@ if(Platform.OS !== "web") {
 } else {
     RNScreenshotPrevent = {
         enabled: (enabled: boolean): void => {
-            console.warn("RNScreenshotPrevent: enabled not work in web. value: "+enabled);
+            console.warn("RNScreenshotPrevent: enabled not work in web. value: " + enabled);
         },
         enableSecureView: (): void => {
             console.warn("RNScreenshotPrevent: enableSecureView not work in web");
@@ -46,7 +50,7 @@ if(Platform.OS !== "web") {
         }
     }
     addListen = (fn: FN): Return => {
-        if(typeof(fn) !== 'function') {
+        if (typeof (fn) !== 'function') {
             console.error('RNScreenshotPrevent: addListener requires valid callback function');
             return {
                 remove: (): void => {


### PR DESCRIPTION
Fixes an issue #39 causing application crashes when passing a parameter to Java, by adding a condition to prevent this problem.

This pull request addresses an issue causing crashes in the application by implementing a crucial condition. Previously, passing a parameter to Java would result in crashes, particularly on Android platforms. To mitigate this, a condition has been added to prevent the parameter from being passed on Android, thus averting the application crashes.


```ts
if (Platform.OS !== "web") {
    const { RNScreenshotPrevent: RNScreenshotPreventNative } = NativeModules;
    RNScreenshotPrevent = {
        ...RNScreenshotPreventNative,
        enableSecureView: function enableSecureView(imagePath = "") {
            if (Platform.OS === "ios") { 
                RNScreenshotPreventNative.enableSecureView(imagePath)
            } else {
                // Added condition to prevent passing imagePath on Android
                RNScreenshotPreventNative.enableSecureView()
            }
        }
}
```
