### PR TITLE
Fix screenshot prevention on iOS

### DIFF
--- a/ios/RNScreenshotPrevent.m
+++ b/ios/RNScreenshotPrevent.m
@@ -127,6 +127,7 @@ CGSize CGSizeAspectFill(const CGSize aspectRatio, const CGSize minimumSize)
             [self initTextField];
         }
         [secureField setSecureTextEntry: TRUE];
+        [secureField setBackgroundColor: UIColor.whiteColor];
     }
 }
 


### PR DESCRIPTION
## Bugfix

- Fix screenshot prevention on iOS 17 not working

## Related issues

https://github.com/killserver/react-native-screenshot-prevent/issues/28

## Approach

- Update `enableSecureView` to create the textfield, and then add the layer to the keyWindow layer, which should be outside the RN rendering cycle
- Update `disableSecureView` to remove the textfield layer from the window layer

## Things to be aware of / Things to focus on

- In my workplace we only needed the screenshot prevention feature to work, so I removed the image functionality, but this could be the proof of concept needed, as I think we can just add the image as a background to the textfield and it should work
  -  I did test that we can show a different color for the background

## Screen recording

https://github.com/killserver/react-native-screenshot-prevent/assets/14112819/5d0a5d4a-7273-4118-9e80-3fe178a4f0ec

