### PR TITLE
fix: Missing enableSecureView override on module export

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,8 +1,8 @@
 declare module 'react-native-screenshot-prevent' {
-  export function enabled(value: boolean): void
-  export function enableSecureView(imagePath?: string): void;
-  export function disableSecureView(): void;
-  export function usePreventScreenshot(): void;
-  export function useDisableSecureView(): void;
-  export function addListener(fn: Function): void;
+	export function enabled(value: boolean): void;
+	export function enableSecureView(imagePath?: string): void;
+	export function disableSecureView(): void;
+	export function usePreventScreenshot(): void;
+	export function useDisableSecureView(): void;
+	export function addListener(fn: Function): void;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,12 @@ if (Platform.OS !== 'web') {
 		NativeScreenshotPrevent ?? NativeModules.RNScreenshotPrevent;
 
 	if (nativeModule) {
-		RNScreenshotPrevent = nativeModule;
+		RNScreenshotPrevent = {
+			...nativeModule,
+			enableSecureView: (imagePath: string = ''): void => {
+				nativeModule.enableSecureView(imagePath);
+			},
+		};
 		const eventEmitter = new NativeEventEmitter(nativeModule);
 
 		addListen = (fn: FN): Return => {


### PR DESCRIPTION
This pull request makes a minor update to how the `RNScreenshotPrevent` native module is handled on non-web platforms. The main change is wrapping the native module to ensure that the `enableSecureView` method always has a default argument, improving its robustness and developer experience.

- Native module handling:
  * Updated the assignment of `RNScreenshotPrevent` to wrap the native module and ensure that `enableSecureView` always receives a default `imagePath` argument, preventing potential errors if the argument is omitted.